### PR TITLE
reset-stale: reset the stale bugs after needinfo is cleared

### DIFF
--- a/manifests/01_config.yaml
+++ b/manifests/01_config.yaml
@@ -37,6 +37,11 @@ data:
       blockers:
         name: openshift-group-b-blockers
         sharerID: 290313
+      resetStale:
+        name: openshift-group-b-reset-stale
+        sharerID: 290313
+        action:
+          addKeyword: LifecycleReset
       staleClose:
         name: openshift-group-b-lifecycle-close
         sharerID: 290313

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -34,6 +34,10 @@ type BugzillaLists struct {
 	// Stale list represents a list with bugs that are not changes for 30d
 	Stale BugzillaList `yaml:"stale"`
 
+	// ResetStale list bugs that were marked as stale but then the need_info flag was reset.
+	// In that case, we will remove the LifecycleStale keyword.
+	ResetStale BugzillaList `yaml:"resetStale"`
+
 	// StaleClose represents a list with bugs we tagged as LifecycleStale and they were not changed 7d after that.
 	StaleClose BugzillaList `yaml:"staleClose"`
 

--- a/pkg/operator/resetcontroller/reset_controller.go
+++ b/pkg/operator/resetcontroller/reset_controller.go
@@ -1,0 +1,87 @@
+package resetcontroller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/eparis/bugzilla"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	errorutil "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/mfojtik/bugzilla-operator/pkg/cache"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/bugutil"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/config"
+	"github.com/mfojtik/bugzilla-operator/pkg/slack"
+)
+
+type ResetStaleController struct {
+	config config.OperatorConfig
+
+	newBugzillaClient             func() cache.BugzillaClient
+	slackClient, slackDebugClient slack.ChannelClient
+}
+
+func NewResetStaleController(operatorConfig config.OperatorConfig, newBugzillaClient func() cache.BugzillaClient, slackClient, slackDebugClient slack.ChannelClient, recorder events.Recorder) factory.Controller {
+	c := &ResetStaleController{
+		config:            operatorConfig,
+		newBugzillaClient: newBugzillaClient,
+		slackClient:       slackClient,
+		slackDebugClient:  slackDebugClient,
+	}
+	return factory.New().WithSync(c.sync).ResyncEvery(1*time.Hour).ToController("ResetStaleController", recorder)
+}
+
+func (c *ResetStaleController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	client := c.newBugzillaClient()
+	bugsToReset, err := client.BugList(c.config.Lists.ResetStale.Name, c.config.Lists.ResetStale.SharerID)
+	if err != nil {
+		syncCtx.Recorder().Warningf("BuglistFailed", err.Error())
+		return err
+	}
+
+	var errors []error
+	var resetBugLinks []string
+	for _, bug := range bugsToReset {
+		bugInfo, err := client.GetCachedBug(bug.ID, bugutil.LastChangeTimeToRevision(bug.LastChangeTime))
+		if err != nil {
+			syncCtx.Recorder().Warningf("BugInfoFailed", "Failed to query bug #%d: %v", bug.ID, err)
+			errors = append(errors, err)
+			continue
+		}
+		if err := client.UpdateBug(bug.ID, bugzilla.BugUpdate{
+			DevWhiteboard: c.config.Lists.ResetStale.Action.AddKeyword,
+			Flags: []bugzilla.FlagChange{
+				{
+					Name:      "needinfo",
+					Status:    "?",
+					Requestee: bugInfo.AssignedTo,
+				},
+			},
+		}); err != nil {
+			syncCtx.Recorder().Warningf("BugCloseFailed", "Failed to close bug #%d: %v", bug.ID, err)
+			errors = append(errors, err)
+			continue
+		}
+
+		resetBugLinks = append(resetBugLinks, bugutil.GetBugURL(*bugInfo))
+		message := fmt.Sprintf("Following bug _LifecycleStale_ was *removed* after the _need_info?_ flag was reset:\n%s\n", bugutil.FormatBugMessage(*bugInfo))
+
+		if err := c.slackClient.MessageEmail(bugInfo.AssignedTo, message); err != nil {
+			syncCtx.Recorder().Warningf("DeliveryFailed", "Failed to deliver close message to %q: %v", bugInfo.AssignedTo, err)
+		}
+		if err := c.slackClient.MessageEmail(bugInfo.Creator, message); err != nil {
+			syncCtx.Recorder().Warningf("DeliveryFailed", "Failed to deliver close message to %q: %v", bugInfo.Creator, err)
+
+		}
+	}
+
+	// Notify admin
+	if len(resetBugLinks) > 0 {
+		c.slackDebugClient.MessageChannel(fmt.Sprintf("%s reset: %s", bugutil.BugCountPlural(len(resetBugLinks), true), strings.Join(resetBugLinks, ",")))
+	}
+
+	return errorutil.NewAggregate(errors)
+}


### PR DESCRIPTION
This controller will watch bug list with bugs marked as `LifecycleStale` BUT the needinfo flag was reset after they were marked.

That indicates response from the reporter and intention to keep the bug open