### PR TITLE
Add first team comment controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/boltdb/bolt v1.3.1
 	github.com/davecgh/go-spew v1.1.1
-	github.com/eparis/bugzilla v0.0.0-20200611221508-8c3833f85c69
+	github.com/eparis/bugzilla v0.0.0-20200703113310-65c18f670c00
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/gorilla/handlers v1.4.2
 	github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131
@@ -25,4 +25,4 @@ require (
 	k8s.io/klog v1.0.0
 )
 
-// replace github.com/eparis/bugzilla => github.com/mfojtik/bugzilla v0.0.0-20200611073413-8c3af3656d03
+replace github.com/eparis/bugzilla => github.com/sttts/bugzilla v0.0.0-20200703113310-65c18f670c00

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,6 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/eparis/bugzilla v0.0.0-20200611221508-8c3833f85c69 h1:L5wjW11irgUzsydVvKjyTalZ4tMn+vLywZ70BtIALro=
-github.com/eparis/bugzilla v0.0.0-20200611221508-8c3833f85c69/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -351,6 +349,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/sttts/bugzilla v0.0.0-20200703113310-65c18f670c00 h1:CgLSuqvmu1o2zAb8wiSCMnedtwnL6rZWUkCDJUpEjnk=
+github.com/sttts/bugzilla v0.0.0-20200703113310-65c18f670c00/go.mod h1:rL9T9C00qg+aIkHUu2ENFSP49Wx9KwF+uSSF0rml5KQ=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/pkg/operator/firstteamcommentcontroller/firstteamcomment_controller.go
+++ b/pkg/operator/firstteamcommentcontroller/firstteamcomment_controller.go
@@ -1,0 +1,138 @@
+package firstteamcommentcontroller
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/eparis/bugzilla"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	errutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog"
+
+	"github.com/mfojtik/bugzilla-operator/pkg/cache"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/config"
+	"github.com/mfojtik/bugzilla-operator/pkg/slack"
+)
+
+type FirstTeamCommentController struct {
+	config            config.OperatorConfig
+	newBugzillaClient func() cache.BugzillaClient
+	slackClient       slack.ChannelClient
+}
+
+func NewFirstTeamCommentController(operatorConfig config.OperatorConfig, newBugzillaClient func() cache.BugzillaClient, slackClient slack.ChannelClient, recorder events.Recorder) factory.Controller {
+	c := &FirstTeamCommentController{
+		config:            operatorConfig,
+		newBugzillaClient: newBugzillaClient,
+		slackClient:       slackClient,
+	}
+	return factory.New().WithSync(c.sync).ResyncEvery(2*time.Hour).ToController("FirstTeamCommentController", recorder)
+}
+
+func (c *FirstTeamCommentController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	client := c.newBugzillaClient()
+	var errors []error
+
+	for name, comp := range c.config.Components {
+		if !comp.AssignFirstDeveloperCommentor {
+			continue
+		}
+		if comp.Lead == "" {
+			continue
+		}
+
+		nonLeads := config.ExpandGroups(c.config.Groups, comp.Developers...)
+		nonLeads = nonLeads.Delete(comp.Lead)
+
+		query := fmt.Sprintf(
+			"email1=%s&email2=%s&emailassigned_to2=1&emaillongdesc1=1&emaillongdesc3=1&emailtype1=regexp&emailtype2=equals",
+			url.QueryEscape(strings.Join(nonLeads.List(), "|")),
+			url.QueryEscape(comp.Lead),
+		)
+		klog.Warning(query)
+		leadAssignedBugs, err := client.Search(bugzilla.Query{
+			Product:   []string{"OpenShift Container Platform"},
+			Status:    []string{"NEW"},
+			Component: []string{name},
+			Raw:       query,
+		})
+		if err != nil {
+			syncCtx.Recorder().Warningf("BuglistFailed", err.Error())
+			continue
+		}
+		klog.Infof("%d NEW bugs found assigned to lead", len(leadAssignedBugs))
+
+	nextBug:
+		for _, b := range leadAssignedBugs {
+			comments, err := client.GetCachedBugComments(b.ID, b.LastChangeTime)
+			if err != nil {
+				syncCtx.Recorder().Warningf("GetCachedBugComments", err.Error())
+				continue
+			}
+
+			var firstTeamCommentor string
+			for _, c := range comments {
+				creator := c.Creator
+				if !strings.ContainsRune(creator, '@') {
+					creator = creator + "@redhat.com"
+				}
+				if strings.Contains(c.Text, "LifecycleStale") {
+					continue
+				}
+				if nonLeads.Has(creator) && firstTeamCommentor == "" && b.Creator != creator {
+					firstTeamCommentor = creator
+				}
+				if creator == comp.Lead {
+					continue nextBug
+				}
+			}
+
+			if firstTeamCommentor == "" {
+				continue
+			}
+
+			history, err := client.GetCachedBugHistory(b.ID, b.LastChangeTime)
+			if err != nil {
+				syncCtx.Recorder().Warningf("GetBugFailed", err.Error())
+				continue
+			}
+
+			for _, h := range history {
+				for _, c := range h.Changes {
+					if c.FieldName != "assigned_to" {
+						continue
+					}
+					if c.Removed == comp.Lead {
+						// this was bounced back before from lead. Don't try again.
+						klog.Infof("Ignoring %v which was bounced from %s before.", b.ID, comp.Lead)
+						continue nextBug
+					}
+					if c.Removed == firstTeamCommentor {
+						// this was bounced back before from first commentor. Don't try again.
+						klog.Infof("Ignoring %v which was bounced from %s before.", b.ID, firstTeamCommentor)
+						continue nextBug
+					}
+
+				}
+			}
+
+			klog.Infof("%s commented on #%v, but lead %s hasn't.\n", firstTeamCommentor, b.ID, comp.Lead)
+			c.slackClient.MessageChannel(fmt.Sprintf("FirstTeamCommentController would reassign %s bug <https://bugzilla.redhat.com/show_bug.cgi?id=%v|#%v %q> to %s due to comments, but lead %s hasn't commented.", name, b.ID, b.ID, b.Summary, firstTeamCommentor, comp.Lead))
+
+			// TODO: enable bugzilla call
+			/*
+				if err := client.UpdateBug(b.ID, bugzilla.BugUpdate{Status: "ASSIGNED", AssignedTo: firstTeamCommentor}); err != nil {
+					klog.Errorf("Failed to assign bug #%v to %s", b.ID)
+					continue
+				}
+				c.slackClient.MessageEmail(comp.Lead, fmt.Sprintf("Assigned %s bug <https://bugzilla.redhat.com/show_bug.cgi?id=%v|#%v %q> to %s due to comments.", name, b.ID, b.ID, b.Summary, firstTeamCommentor))
+			*/
+		}
+	}
+
+	return errutil.NewAggregate(errors)
+}

--- a/pkg/operator/firstteamcommentcontroller/firstteamcomment_controller_test.go
+++ b/pkg/operator/firstteamcommentcontroller/firstteamcomment_controller_test.go
@@ -1,0 +1,53 @@
+package firstteamcommentcontroller
+
+import (
+	"os"
+	"testing"
+
+	"github.com/eparis/bugzilla"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/mfojtik/bugzilla-operator/pkg/cache"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/config"
+)
+
+func TestNewFirstTeamCommentController(t *testing.T) {
+	// SKIPPED
+	// remove to run locally
+	return
+
+	cache.Open("/tmp/bolt")
+	c := &FirstTeamCommentController{
+		config: config.OperatorConfig{
+			Groups: map[string]config.Group{
+				"admins":   {"mfojtik@redhat.com", "sttts@redhat.com"},
+				"leads":    {"deads@redhat.com", "sbatsche@redhat.com", "maszulik@redhat.com", "mfojtik@redhat.com", "sttts@redhat.com"},
+				"api-auth": {"sttts@redhat.com", "deads@redhat.com", "lszaszki@redhat.com", "slaznick@redhat.com", "akashem@redhat.com", "lusanche@redhat.com", "vareti@redhat.com", "mnewby@redhat.com"},
+			},
+			Components: map[string]config.Component{
+				"kube-apiserver": {
+					Lead:                          "sttts@redhat.com",
+					Developers:                    []string{"group:api-auth"},
+					AssignFirstDeveloperCommentor: true,
+				},
+				"api-auth": {
+					Lead:                          "sttts@redhat.com",
+					Developers:                    []string{"group:api-auth"},
+					AssignFirstDeveloperCommentor: true,
+				},
+				"openshift-apiserver": {
+					Lead:                          "sttts@redhat.com",
+					Developers:                    []string{"group:api-auth"},
+					AssignFirstDeveloperCommentor: true,
+				},
+			},
+		},
+		newBugzillaClient: func() cache.BugzillaClient {
+			return cache.NewCachedBugzillaClient(bugzilla.NewClient(func() []byte {
+				return []byte(os.Getenv("BUGZILLA_TOKEN"))
+			}, "https://bugzilla.redhat.com"))
+		},
+	}
+	c.sync(nil, factory.NewSyncContext("foo", events.NewLoggingEventRecorder("TestNewFirstTeamCommentController")))
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mfojtik/bugzilla-operator/pkg/cache"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/closecontroller"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/config"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/firstteamcommentcontroller"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/reporters/blockers"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/reporters/closed"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/resetcontroller"
@@ -65,6 +66,8 @@ func Run(ctx context.Context, cfg config.OperatorConfig) error {
 
 	// close stale controller automatically close bugs that were not updated after marked LifecycleClose for 7 days
 	closeStaleController := closecontroller.NewCloseStaleController(cfg, newBugzillaClient(&cfg), slackAdminClient, slackDebugClient, recorder)
+
+	firstTeamCommentController := firstteamcommentcontroller.NewFirstTeamCommentController(cfg, newBugzillaClient(&cfg), slackAdminClient, recorder)
 
 	allBlockersReporter := blockers.NewBlockersReporter(cfg.Components.List(), nil, cfg, newBugzillaClient(&cfg), slackAdminClient, slackDebugClient, recorder)
 	allClosedReporter := closed.NewClosedReporter(cfg.Components.List(), nil, cfg, newBugzillaClient(&cfg), slackAdminClient, recorder)
@@ -188,6 +191,8 @@ func Run(ctx context.Context, cfg config.OperatorConfig) error {
 	go staleController.Run(ctx, 1)
 	go staleResetController.Run(ctx, 1)
 	go closeStaleController.Run(ctx, 1)
+	go firstTeamCommentController.Run(ctx, 1)
+
 	go slackerInstance.Run(ctx)
 
 	<-ctx.Done()

--- a/vendor/github.com/eparis/bugzilla/types.go
+++ b/vendor/github.com/eparis/bugzilla/types.go
@@ -231,6 +231,7 @@ type BugUpdate struct {
 	Priority      string       `json:"priority,omitempty"`
 	Severity      string       `json:"severity,omitempty"`
 	MinorUpdate   bool         `json:"minor_update,omitempty"`
+	AssignedTo    string       `json:"assigned_to,omitempty"`
 }
 
 // ExternalBug contains details about an external bug linked to a Bugzilla bug.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/cespare/xxhash/v2
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/eparis/bugzilla v0.0.0-20200611221508-8c3833f85c69
+# github.com/eparis/bugzilla v0.0.0-20200703113310-65c18f670c00 => github.com/sttts/bugzilla v0.0.0-20200703113310-65c18f670c00
 ## explicit
 github.com/eparis/bugzilla
 # github.com/gogo/protobuf v1.3.1
@@ -450,3 +450,4 @@ k8s.io/utils/trace
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# github.com/eparis/bugzilla => github.com/sttts/bugzilla v0.0.0-20200703113310-65c18f670c00


### PR DESCRIPTION
When a team member comments, but the lead hasn't, the BZ is automatically assigned to that team member, and the lead is informed via private Slack message.