### PR TITLE
Fix external_bugzilla.description logic

### DIFF
--- a/pkg/operator/closecontroller/close_controller.go
+++ b/pkg/operator/closecontroller/close_controller.go
@@ -101,9 +101,10 @@ func getBugsToClose(client cache.BugzillaClient, c config.OperatorConfig) ([]*bu
 				Value: "LifecycleStale",
 			},
 			{
-				Field: "external_bugzilla.description",
-				Op:    "notsubstring",
-				Value: "Customer Portal",
+				Negate: true,
+				Field:  "external_bugzilla.description",
+				Op:     "substring",
+				Value:  "Customer Portal",
 			},
 		},
 		IncludeFields: []string{

--- a/pkg/operator/stalecontroller/stale_controller.go
+++ b/pkg/operator/stalecontroller/stale_controller.go
@@ -211,13 +211,15 @@ func getPotentiallyStaleBugs(client cache.BugzillaClient, c config.OperatorConfi
 				Value: "LifecycleStale",
 			},
 			{
+				Negate: true,
 				Field: "external_bugzilla.description",
-				Op:    "notsubstring",
+				Op:    "substring",
 				Value: "Customer Portal",
 			},
 			{
+				Negate: true,
 				Field: "external_bugzilla.description",
-				Op:    "notsubstring",
+				Op:    "substring",
 				Value: "Github",
 			},
 			{


### PR DESCRIPTION
`external_bugzilla.description substring "X"` means that one of the external links have X in the description. I.e. to negate that you cannot just switch to `notsubstring`, but you have to negate the whole expression:

```
NOT (external_bugzilla.description substring "X")
```