### PR TITLE
reassign: cover bug reassigning ping pong ping

### DIFF
--- a/pkg/operator/reassigncontroller/reassign_controller.go
+++ b/pkg/operator/reassigncontroller/reassign_controller.go
@@ -1,0 +1,103 @@
+package reassigncontroller
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/klog"
+
+	"github.com/eparis/bugzilla"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/mfojtik/bugzilla-operator/pkg/cache"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/config"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/controller"
+)
+
+type ReassignController struct {
+	context controller.ControllerContext
+	config  *config.OperatorConfig
+}
+
+func NewReassignController(ctx controller.ControllerContext, operatorConfig config.OperatorConfig, recorder events.Recorder) factory.Controller {
+	c := &ReassignController{context: ctx, config: &operatorConfig}
+	return factory.New().WithSync(c.sync).ResyncEvery(1*time.Hour).ToController("ReassignController", recorder)
+}
+
+func (c *ReassignController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
+	client := c.context.NewBugzillaClient(ctx)
+	assigneeNotifiedBugs, err := getAssigneeNotifiedBugsList(client, c.config)
+	if err != nil {
+		syncCtx.Recorder().Warningf("BuglistFailed", err.Error())
+		return err
+	}
+
+	for _, bug := range assigneeNotifiedBugs {
+		history, err := client.GetCachedBugHistory(bug.ID, bug.LastChangeTime)
+		if err != nil {
+			syncCtx.Recorder().Warningf("GetBugFailed", err.Error())
+			continue
+		}
+		var (
+			whenNotified         time.Time
+			whenComponentChanged *time.Time
+		)
+		for _, h := range history {
+			changedAt, err := time.Parse(time.RFC3339, h.When)
+			if err != nil {
+				klog.Errorf("unable to parse change time %q for bug %+v: %v", h.When, bug, err)
+				continue
+			}
+			for _, change := range h.Changes {
+				switch change.FieldName {
+				case "cf_devel_whiteboard":
+					whenNotified = changedAt
+				case "component":
+					whenComponentChanged = &changedAt
+				}
+			}
+		}
+
+		if whenComponentChanged != nil && whenComponentChanged.After(whenNotified) {
+			if err := client.UpdateBug(bug.ID, bugzilla.BugUpdate{
+				DevWhiteboard: "",
+				MinorUpdate:   true,
+			}); err != nil {
+				syncCtx.Recorder().Warningf("ResetNotificationFailed", "Failed to updated bug #%d: %v", bug.ID, err)
+				continue
+			}
+			syncCtx.Recorder().Eventf("BugReassigned", "Cleared AssigneeNotified for bug #%d because component changed", bug.ID)
+		}
+	}
+	return nil
+}
+
+func getAssigneeNotifiedBugsList(client cache.BugzillaClient, config *config.OperatorConfig) ([]*bugzilla.Bug, error) {
+	return client.Search(bugzilla.Query{
+		Classification: []string{"Red Hat"},
+		Product:        []string{"OpenShift Container Platform"},
+		Status:         []string{"NEW", "ASSIGNED"},
+		Component:      config.Components.List(),
+		Advanced: []bugzilla.AdvancedQuery{
+			{
+				Field: "cf_devel_whiteboard",
+				Op:    "substring",
+				Value: "AssigneeNotified",
+			},
+		},
+		IncludeFields: []string{
+			"id",
+			"assigned_to",
+			"keywords",
+			"status",
+			"component",
+			"resolution",
+			"summary",
+			"severity",
+			"priority",
+			"target_release",
+			"whiteboard",
+		},
+	})
+}

--- a/pkg/operator/reassigncontroller/reassign_controller_test.go
+++ b/pkg/operator/reassigncontroller/reassign_controller_test.go
@@ -1,0 +1,192 @@
+package reassigncontroller
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/mfojtik/bugzilla-operator/pkg/cache"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/config"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/controller"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/eparis/bugzilla"
+)
+
+type testBugzillaClient struct {
+	bugs            []*bugzilla.Bug
+	bugsWithHistory map[int][]bugzilla.History
+	bugUpdates      []bugzilla.BugUpdate
+}
+
+func (t *testBugzillaClient) Endpoint() string {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) GetBug(id int) (*bugzilla.Bug, error) {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) GetBugComments(id int) ([]bugzilla.Comment, error) {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) GetBugHistory(id int) ([]bugzilla.History, error) {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) Search(query bugzilla.Query) ([]*bugzilla.Bug, error) {
+	return t.bugs, nil
+}
+
+func (t *testBugzillaClient) GetExternalBugPRsOnBug(id int) ([]bugzilla.ExternalBug, error) {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) UpdateBug(id int, update bugzilla.BugUpdate) error {
+	t.bugUpdates = append(t.bugUpdates, update)
+	return nil
+}
+
+func (t *testBugzillaClient) AddPullRequestAsExternalBug(id int, org, repo string, num int) (bool, error) {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) WithCGIClient(user, password string) bugzilla.Client {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) BugList(queryName, sharerID string) ([]bugzilla.Bug, error) {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) GetCachedBug(id int, lastChangedTime string) (*bugzilla.Bug, error) {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) GetCachedBugComments(id int, lastChangedTime string) ([]bugzilla.Comment, error) {
+	panic("implement me")
+}
+
+func (t *testBugzillaClient) GetCachedBugHistory(id int, lastChangedTime string) ([]bugzilla.History, error) {
+	return t.bugsWithHistory[id], nil
+}
+
+func TestNewReassignController(t *testing.T) {
+	tests := []struct {
+		name            string
+		history         []bugzilla.History
+		expectedUpdated []bugzilla.BugUpdate
+	}{
+		{
+			name: "component changed after we notified assignee",
+			history: []bugzilla.History{
+				{
+					When: "2020-01-01T12:00:00Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "cf_devel_whiteboard",
+						},
+					},
+				},
+				{
+					When: "2020-01-01T12:05:00Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+						},
+					},
+				},
+			},
+			expectedUpdated: []bugzilla.BugUpdate{
+				{
+					DevWhiteboard: "",
+					MinorUpdate:   true,
+				},
+			},
+		},
+		{
+			name: "component never changed",
+			history: []bugzilla.History{
+				{
+					When: "2020-01-01T12:00:00Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "cf_devel_whiteboard",
+						},
+					},
+				},
+			},
+			expectedUpdated: []bugzilla.BugUpdate{},
+		},
+		{
+			name: "component changed multiple times but we catched up",
+			history: []bugzilla.History{
+				{
+					When: "2020-01-01T12:00:00Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "cf_devel_whiteboard",
+						},
+					},
+				},
+				{
+					When: "2020-01-01T12:05:00Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+						},
+					},
+				},
+				{
+					When: "2020-01-01T12:10:00Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+						},
+					},
+				},
+				{
+					When: "2020-01-01T12:15:00Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "cf_devel_whiteboard",
+						},
+					},
+				},
+			},
+			expectedUpdated: []bugzilla.BugUpdate{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testClient := &testBugzillaClient{
+				bugs: []*bugzilla.Bug{{
+					ID: 1,
+				}},
+				bugsWithHistory: map[int][]bugzilla.History{
+					1: test.history,
+				},
+			}
+			ctx := controller.NewControllerContext(func(debug bool) cache.BugzillaClient {
+				return testClient
+			}, nil, nil, nil)
+			c := &ReassignController{
+				context: ctx,
+				config:  &config.OperatorConfig{Components: map[string]config.Component{}},
+			}
+			if err := c.sync(context.TODO(), factory.NewSyncContext("test", events.NewInMemoryRecorder("test"))); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if testClient.bugUpdates == nil {
+				testClient.bugUpdates = []bugzilla.BugUpdate{}
+			}
+			if !reflect.DeepEqual(testClient.bugUpdates, test.expectedUpdated) {
+				t.Errorf("expected:\n%#v\ngot:\n%#v", test.expectedUpdated, testClient.bugUpdates)
+			}
+		})
+	}
+
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/reassigncontroller"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/eparis/bugzilla"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -85,6 +87,7 @@ func Run(ctx context.Context, cfg config.OperatorConfig) error {
 		"close-stale":        closecontroller.NewCloseStaleController(controllerContext, cfg, recorder),
 		"first-team-comment": firstteamcommentcontroller.NewFirstTeamCommentController(controllerContext, cfg, recorder),
 		"new":                newcontroller.NewNewBugController(controllerContext, cfg, recorder),
+		"reassign":           reassigncontroller.NewReassignController(controllerContext, cfg, recorder),
 	}
 
 	// TODO: enable by default


### PR DESCRIPTION
This controller covers the reassign "ping, pong, ping". In case the bug is moved back to original component but we already notified the assignee (AssigneeNotified), the controller we remove this label and allow "incoming" reporting to notify assignee again.