### PR TITLE
reassign: add report that tell us how bugs move between components

### DIFF
--- a/pkg/cache/fake_bugzilla.go
+++ b/pkg/cache/fake_bugzilla.go
@@ -1,12 +1,17 @@
 package cache
 
 import (
-	"github.com/eparis/bugzilla"
 	"time"
+
+	"github.com/eparis/bugzilla"
 )
 
 type FakeBugzillaClient struct {
 	*bugzilla.Fake
+}
+
+func (f *FakeBugzillaClient) GetCachedExternalBugs(id int, lastChangedTime string) ([]bugzilla.ExternalBug, error) {
+	return f.GetCachedExternalBugs(id, lastChangedTime)
 }
 
 func (f *FakeBugzillaClient) GetCachedBug(id int, lastChangedTime string) (*bugzilla.Bug, time.Duration, error) {

--- a/pkg/operator/bugutil/format.go
+++ b/pkg/operator/bugutil/format.go
@@ -14,10 +14,28 @@ func GetBugURL(b bugzilla.Bug) string {
 	return fmt.Sprintf("<https://bugzilla.redhat.com/show_bug.cgi?id=%d|#%d>", b.ID, b.ID)
 }
 
+// 2020-09-23T13:06:29Z
+
+func ParseChangeWhenString(v string) time.Time {
+	parsedTime, err := time.Parse("2006-01-02T15:04:05Z", v)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsedTime
+}
+
+func ParseTimeString(v string) time.Time {
+	parsedTime, err := time.Parse("2006-01-02 15:04:05 -0700 MST", v)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsedTime
+}
+
 // ParseLastChangeTime parse the "2020-05-20 10:45:16 +0000 UTC" to "2020-05-20T10:45:16Z" which can be used for cache revision.
 func LastChangeTimeToRevision(value string) string {
-	parsedTime, err := time.Parse("2006-01-02 15:04:05 -0700 MST", value)
-	if err != nil {
+	parsedTime := ParseTimeString(value)
+	if parsedTime.IsZero() {
 		return value
 	}
 	return parsedTime.Format("2006-01-02T15:04:05Z")

--- a/pkg/operator/reporters/reassign/reassign_reporter.go
+++ b/pkg/operator/reporters/reassign/reassign_reporter.go
@@ -1,0 +1,294 @@
+package reassign
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/eparis/bugzilla"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/mfojtik/bugzilla-operator/pkg/cache"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/bugutil"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/config"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/controller"
+)
+
+// ReassignReporter lists all OpenShift bugs which has a change recorded in last 7 days. If that change was component change it persist the incoming and outgoing (target)
+// component as "component change". It reports then the top incoming and outgoing component for last 7 days.
+type ReassignReporter struct {
+	controller.ControllerContext
+	config config.OperatorConfig
+
+	// for unit testing
+	writeReportFn func(ctx context.Context, bugs []bug) error
+	readReportFn  func(ctx context.Context) ([]bug, error)
+	getBugHistory func(int, string) ([]bugzilla.History, error)
+}
+
+type componentChange struct {
+	From string    `json:"from"`
+	To   string    `json:"to"`
+	When time.Time `json:"when"`
+}
+
+type bug struct {
+	ID                  int               `json:"id"`
+	ComponentChanges    []componentChange `json:"component_changes"`
+	LastComponentChange time.Time         `json:"last_component_change"`
+}
+
+type componentCounter struct {
+	counts []componentCount
+}
+
+func (c *componentCounter) byCount() []componentCount {
+	sortedCounter := c.counts
+	sort.Slice(c.counts, func(i, j int) bool {
+		return sortedCounter[i].count >= sortedCounter[j].count
+	})
+	return sortedCounter
+}
+
+func (c *componentCounter) Inc(name string) {
+	for i := range c.counts {
+		if c.counts[i].name == name {
+			c.counts[i].count += 1
+			return
+		}
+	}
+	c.counts = append(c.counts, componentCount{
+		name:  name,
+		count: 1,
+	})
+}
+
+type componentCount struct {
+	name  string
+	count int
+}
+
+func Report(ctx context.Context, controllerCtx controller.ControllerContext, recorder events.Recorder, config *config.OperatorConfig) (string, error) {
+	c := &ReassignReporter{ControllerContext: controllerCtx}
+	currentBugs, err := c.getReport(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	topToComponents := &componentCounter{}
+	topFromComponents := &componentCounter{}
+
+	for _, b := range currentBugs {
+		// only report component changes that happened in last week
+		if !b.LastComponentChange.After(time.Now().Add(-7 * 24 * time.Hour)) {
+			continue
+		}
+		for _, c := range b.ComponentChanges {
+			topFromComponents.Inc(c.From)
+			topToComponents.Inc(c.To)
+		}
+	}
+
+	result := []string{
+		"*Top Incoming Components this Week*:",
+	}
+	for _, c := range topFromComponents.byCount() {
+		result = append(result, fmt.Sprintf("> %s (%d)\n", c.name, c.count))
+	}
+	result = append(result, "*Top Outgoing Components this Week:*")
+	for _, c := range topToComponents.byCount() {
+		result = append(result, fmt.Sprintf("> %s (%d)\n", c.name, c.count))
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func NewReassignReporter(controllerCtx controller.ControllerContext, schedule []string, operatorConfig config.OperatorConfig, recorder events.Recorder) factory.Controller {
+	c := &ReassignReporter{
+		ControllerContext: controllerCtx,
+		config:            operatorConfig,
+	}
+
+	c.readReportFn = c.getReport
+	c.writeReportFn = c.writeReport
+	c.getBugHistory = c.NewBugzillaClient(context.TODO()).GetCachedBugHistory
+
+	return factory.New().WithSync(c.sync).ResyncSchedule(schedule...).ToController("ReassignReporter", recorder)
+}
+
+func (c *ReassignReporter) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	client := c.NewBugzillaClient(ctx)
+
+	bugs, err := getReassignedBugs(client, &c.config)
+	if err != nil {
+		syncContext.Recorder().Warningf("FetchBugs", "Unable to fetch reassigned bugs: %v", err)
+		return err
+	}
+
+	bugsWithTransitions, err := c.readReportFn(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, b := range bugs {
+		history, err := c.getBugHistory(b.ID, b.LastChangeTime)
+		if err != nil {
+			syncContext.Recorder().Warningf("GetBugHistory", "Failed to get bug %d history: %v", b.ID, err)
+		}
+		transitions := []componentChange{}
+		var lastComponentChange time.Time
+
+		for _, h := range history {
+			for _, change := range h.Changes {
+				if change.FieldName != "component" {
+					continue
+				}
+
+				when := bugutil.ParseChangeWhenString(h.When)
+				if when.After(lastComponentChange) {
+					lastComponentChange = when
+				}
+
+				transitions = append(transitions, componentChange{
+					When: when,
+					From: change.Removed,
+					To:   change.Added,
+				})
+			}
+
+		}
+
+		// check whether the transition of the bug include component (from or to) we watch (configured in config)
+		allTransitions := []componentChange{}
+		allTransitions = append(allTransitions, transitions...)
+		allTransitions = append(allTransitions, getCachedBugTransitions(bugsWithTransitions, b.ID)...)
+		if !c.matchConfiguredComponent(allTransitions) {
+			continue
+		}
+
+		pos, hasChange := hasNewTransitions(bugsWithTransitions, b.ID, transitions)
+		if !hasChange {
+			continue
+		}
+
+		if pos != -1 { // existing bug
+			bugsWithTransitions[pos] = bug{
+				ID:                  b.ID,
+				ComponentChanges:    transitions,
+				LastComponentChange: lastComponentChange,
+			}
+		} else { // new bug
+			bugsWithTransitions = append(bugsWithTransitions, bug{
+				ID:                  b.ID,
+				ComponentChanges:    transitions,
+				LastComponentChange: lastComponentChange,
+			})
+		}
+	}
+
+	return c.writeReportFn(ctx, bugsWithTransitions)
+}
+
+func getCachedBugTransitions(bugs []bug, id int) []componentChange {
+	for i := range bugs {
+		if bugs[i].ID == id {
+			return bugs[i].ComponentChanges
+		}
+	}
+	return []componentChange{}
+}
+
+func getCachedBugPos(bugs []bug, id int) int {
+	for i := range bugs {
+		if id == bugs[i].ID {
+			return i
+		}
+	}
+	return -1
+}
+
+// hasNewTransitions checks whether a bug has new component changes or not.
+// if the bug is not persisted in storage, this returns true.
+// it returns index in storage where the bug is persisted.
+func hasNewTransitions(bugs []bug, id int, newChanges []componentChange) (int, bool) {
+	oldChanges := getCachedBugTransitions(bugs, id)
+	// this is new bug, we should add it to cache
+	if len(oldChanges) == 0 {
+		return -1, true
+	}
+	sort.Slice(newChanges, func(i, j int) bool {
+		return newChanges[i].When.After(newChanges[j].When)
+	})
+	sort.Slice(oldChanges, func(i, j int) bool {
+		return oldChanges[i].When.After(oldChanges[j].When)
+	})
+	// no changes
+	if reflect.DeepEqual(oldChanges, newChanges) {
+		return -1, false
+	}
+	// we track this bug and it has new changes
+	return getCachedBugPos(bugs, id), true
+}
+
+// writeReport persist the current bug component transitions into permanent storage (config map) in JSON
+func (c *ReassignReporter) writeReport(ctx context.Context, bugs []bug) error {
+	bytes, err := json.Marshal(&bugs)
+	if err != nil {
+		return err
+	}
+	return c.SetPersistentValue(ctx, "transitions", string(bytes))
+}
+
+// getReport gets the current bug component transitions from permanent storage (config map) in JSON
+func (c *ReassignReporter) getReport(ctx context.Context) ([]bug, error) {
+	bugJSON, err := c.GetPersistentValue(ctx, "transitions")
+	if err != nil {
+		return nil, err
+	}
+	if len(bugJSON) == 0 {
+		return []bug{}, nil
+	}
+	var bugs []bug
+	if err := json.Unmarshal([]byte(bugJSON), &bugs); err != nil {
+		return nil, err
+	}
+	return bugs, nil
+}
+
+// matchConfiguredComponent check whether the transition include component of interest (from config)
+func (c *ReassignReporter) matchConfiguredComponent(transitions []componentChange) bool {
+	components := sets.NewString(c.config.Components.List()...)
+	for _, t := range transitions {
+		if components.Has(t.From) || components.Has(t.To) {
+			return true
+		}
+	}
+	return false
+}
+
+func getReassignedBugs(client cache.BugzillaClient, config *config.OperatorConfig) ([]*bugzilla.Bug, error) {
+	return client.Search(bugzilla.Query{
+		Classification: []string{"Red Hat"},
+		Product:        []string{"OpenShift Container Platform"},
+		Status:         []string{"NEW", "ASSIGNED", "POST"},
+		Component:      config.Components.List(),
+		Advanced: []bugzilla.AdvancedQuery{
+			{
+				// get all bugs that changed their component in the last week
+				Field: "component",
+				Op:    "changedafter",
+				Value: "-1w",
+			},
+		},
+		IncludeFields: []string{
+			"id",
+		},
+	})
+}

--- a/pkg/operator/reporters/reassign/reassign_test.go
+++ b/pkg/operator/reporters/reassign/reassign_test.go
@@ -1,0 +1,210 @@
+package reassign
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/bugutil"
+
+	"github.com/eparis/bugzilla"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/config"
+
+	"github.com/mfojtik/bugzilla-operator/pkg/cache"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/controller"
+)
+
+func fakeBugClient(bugs map[int]bugzilla.Bug) func(bool) cache.BugzillaClient {
+	return func(bool) cache.BugzillaClient {
+		return &cache.FakeBugzillaClient{
+			Fake: &bugzilla.Fake{
+				Bugs: bugs,
+			},
+		}
+	}
+}
+
+func fakeBugHistory(history map[int][]bugzilla.History) func(int, string) ([]bugzilla.History, error) {
+	return func(id int, _ string) ([]bugzilla.History, error) {
+		return history[id], nil
+	}
+}
+
+func TestReassignReport(t *testing.T) {
+	storage := []bug{
+		{
+			ID: 3,
+			ComponentChanges: []componentChange{
+				{
+					From: "kube-apiserver",
+					To:   "openshift-apiserver",
+					When: bugutil.ParseChangeWhenString("2006-01-02T15:04:05Z"),
+				},
+				{
+					From: "openshift-apiserver",
+					To:   "etcd",
+					When: bugutil.ParseChangeWhenString("2006-01-03T15:04:05Z"),
+				},
+			},
+			LastComponentChange: time.Time{},
+		},
+	}
+
+	r := &ReassignReporter{
+		ControllerContext: controller.NewControllerContext(fakeBugClient(
+			map[int]bugzilla.Bug{
+				1: {ID: 1},
+				2: {ID: 2},
+				3: {ID: 3},
+			},
+		), nil, nil, nil),
+		getBugHistory: fakeBugHistory(map[int][]bugzilla.History{
+			// This bug should be added to storage
+			1: {
+				{
+					When: "2006-01-02T15:04:05Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+							Removed:   "kube-apiserver",
+							Added:     "Networking",
+						},
+					},
+				},
+				{
+					When: "2006-01-03T15:04:05Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+							Removed:   "Networking",
+							Added:     "installer",
+						},
+					},
+				},
+			},
+			// This bug should be ignored as there is no interesting component here
+			2: {
+				{
+					When: "2006-01-02T15:04:05Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+							Removed:   "openshift-apiserver",
+							Added:     "etcd",
+						},
+					},
+				},
+				{
+					When: "2006-01-03T15:04:05Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+							Removed:   "etcd",
+							Added:     "Networking",
+						},
+					},
+				},
+			},
+			// This bug should be updated in storage to include new transitions
+			3: {
+				{
+					When: "2006-01-02T15:04:05Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+							Removed:   "kube-apiserver",
+							Added:     "openshift-apiserver",
+						},
+					},
+				},
+				{
+					When: "2006-01-03T15:04:05Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+							Removed:   "openshift-apiserver",
+							Added:     "etcd",
+						},
+					},
+				},
+				{
+					When: "2006-01-04T15:04:05Z",
+					Changes: []bugzilla.HistoryChange{
+						{
+							FieldName: "component",
+							Removed:   "etcd",
+							Added:     "Networking",
+						},
+					},
+				},
+			},
+		}),
+
+		config: config.OperatorConfig{
+			Components: map[string]config.Component{"kube-apiserver": {}},
+		},
+		writeReportFn: func(ctx context.Context, bugs []bug) error {
+			storage = bugs
+			return nil
+		},
+		readReportFn: func(ctx context.Context) ([]bug, error) {
+			return storage, nil
+		},
+	}
+
+	if err := r.sync(context.TODO(), factory.NewSyncContext("test", events.NewInMemoryRecorder("test"))); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, b := range storage {
+		if b.ID == 2 {
+			t.Errorf("bug without transitions in components of interest should not be reported (bug#2:\n%s\n)", spew.Sdump(storage))
+		}
+	}
+
+	if len(storage) != 2 {
+		t.Errorf("expected exactly 2 bugs be reported, got %d:\n%s\n", len(storage), spew.Sdump(storage))
+	}
+
+	for _, b := range storage {
+		if b.ID != 3 {
+			continue
+		}
+		if len(b.ComponentChanges) != 3 {
+			t.Errorf("expected exactly 3 transitions reported for bug#3, got %d:\n%s\n", len(b.ComponentChanges), spew.Sdump(b.ComponentChanges))
+		}
+	}
+}
+
+func TestCounter(t *testing.T) {
+	c := &componentCounter{}
+	c.counts = append(c.counts, []componentCount{
+		{
+			name:  "c1",
+			count: 5,
+		},
+		{
+			name:  "c2",
+			count: 1,
+		},
+		{
+			name:  "c3",
+			count: 10,
+		},
+	}...)
+	c.Inc("c2")
+	counts := c.byCount()
+
+	if counts[0].name != "c3" {
+		t.Errorf("expected first item to be c3 with highest count, got %v", counts[0])
+	}
+	if counts[2].name != "c2" && counts[2].count != 2 {
+		t.Errorf("expected last item to be c2 with count==2, got %v", counts[2])
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/reporters/closed"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/reporters/escalation"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/reporters/incoming"
+	"github.com/mfojtik/bugzilla-operator/pkg/operator/reporters/reassign"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/reporters/upcomingsprint"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/resetcontroller"
 	"github.com/mfojtik/bugzilla-operator/pkg/operator/stalecontroller"
@@ -117,6 +118,8 @@ func Run(ctx context.Context, cfg config.OperatorConfig) error {
 			return incoming.NewIncomingReporter(ctx, when, cfg, recorder)
 		case "incoming-stats":
 			return incoming.NewIncomingStatsReporter(ctx, when, cfg, recorder)
+		case "moved-bugs":
+			return reassign.NewReassignReporter(ctx, when, cfg, recorder)
 		case "closed-bugs":
 			return closed.NewClosedReporter(ctx, components, when, cfg, recorder)
 		case "upcoming-sprint":
@@ -243,6 +246,11 @@ func Run(ctx context.Context, cfg config.OperatorConfig) error {
 				"incoming-stats": func(ctx context.Context, client cache.BugzillaClient) (string, error) {
 					// TODO: restrict components to one team
 					report, err := incoming.ReportStats(ctx, controllerContext, recorder, &cfg)
+					return report, err
+				},
+				"moved-bugs": func(ctx context.Context, client cache.BugzillaClient) (string, error) {
+					// TODO: restrict components to one team
+					report, err := reassign.Report(ctx, controllerContext, recorder, &cfg)
 					return report, err
 				},
 				"upcoming-sprint": func(ctx context.Context, client cache.BugzillaClient) (string, error) {


### PR DESCRIPTION
This reporter will watch **all** bugs in the OpenShift product that changed their component in last 7 days. For every bug, it iterate over its history and extract the component change transitions. If there is at least one transition that is from or to of component of interest, record it.

As a result, this reporter should give counters for "incoming" components (which component a bug was moved) and outgoing component (where the bug was moved). 

TODO: We also watch transitions that are outside of interesting component if the bug was reported to us... This can skew the data if teams outside this group ping-pong the bug between them (but still interesting to watch ;-).

