### PR TITLE
Deal with blocker flags

### DIFF
--- a/pkg/operator/reporters/blockers/blockers_reporter.go
+++ b/pkg/operator/reporters/blockers/blockers_reporter.go
@@ -146,18 +146,6 @@ func getBugsQuery(config *config.OperatorConfig, components []string, targetRele
 		Status:         []string{"NEW", "ASSIGNED", "POST", "ON_DEV"},
 		Component:      components,
 		TargetRelease:  targetRelease,
-		Advanced: []bugzilla.AdvancedQuery{
-			{
-				Field: "bug_severity",
-				Op:    "notequals",
-				Value: "low",
-			},
-			{
-				Field: "priority",
-				Op:    "notequals",
-				Value: "low",
-			},
-		},
 		IncludeFields: []string{
 			"id",
 			"assigned_to",


### PR DESCRIPTION
The blockers reporter only included bugs that are not "low" priority or "low" severity. That led to mismatch between what BU tracks vs. what the bot tracks. This fix will include low priority bugs as well.

In addition, the stale controller, when moving a stale bug priority to "low" should also set the blocker- automatically as the "low" priority bugs are unlikely a release blockers.